### PR TITLE
Allow the same asset to be attached multiple times

### DIFF
--- a/app/assets/javascripts/slices/app/helpers/assets.js
+++ b/app/assets/javascripts/slices/app/helpers/assets.js
@@ -2,9 +2,16 @@
 //
 // Within the attachmentComposer, define the html for the fields the composer
 // should display. Here, we’re assuming there’s a field on the slice called
-// `myAttachments`.
+// `slides`.
 //
-//     {{#attachmentComposer myAttachments}}
+//     {{#attachmentComposer field="slides"}}
+//       <textarea name="caption" class="full-height">{{caption}}</textarea>
+//     {{/attachmentComposer}}
+//
+// By default, attachment composer does not allow the same asset to be added
+// twice. To allow duplicates, set the `allowDupes` option to true:
+//
+//     {{#attachmentComposer field="slides" allowDupes=true}}
 //       <textarea name="caption" class="full-height">{{caption}}</textarea>
 //     {{/attachmentComposer}}
 //
@@ -23,7 +30,8 @@ Handlebars.registerHelper('attachmentComposer', function(options) {
     id         : slices.fieldId(this, options.hash.field),
     collection : this[options.hash.field],
     fields     : options.fn,
-    autoAttach : true
+    autoAttach : true,
+    allowDupes : options.hash.allowDupes
   });
 
   // Return the placeholder. Don’t worry, this is replaced automatically later.

--- a/app/assets/javascripts/slices/app/views/attachment_composer_view.js
+++ b/app/assets/javascripts/slices/app/views/attachment_composer_view.js
@@ -302,7 +302,7 @@ slices.AttachmentComposerView = Backbone.View.extend({
         position = p ? p.index : this.collection.length;
 
     _.each(assets, function(asset) {
-      if (this.alreadyContains(asset)) return;
+      if (!this.options.allowDupes && this.alreadyContains(asset)) return;
       this.collection.add({ asset: asset, asset_id: asset.get('id') }, { at: position });
       position += 1;
     }, this);

--- a/app/slices/slideshow/templates/slideshow.hbs
+++ b/app/slices/slideshow/templates/slideshow.hbs
@@ -1,5 +1,5 @@
 <li>
-  {{#attachmentComposer field="slides"}}
+  {{#attachmentComposer field="slides" allowDupes=true}}
     <textarea name="caption" placeholder="Caption…" rows="9">{{caption}}</textarea>
     <input
       type="text"


### PR DESCRIPTION
This patch removes the duplication checking from `{{attachment-composer}}`, allowing the same asset to be added multiple times.
