### PR TITLE
Add custom entry template mechanism

### DIFF
--- a/app/assets/javascripts/slices/app/backbones/entries.js
+++ b/app/assets/javascripts/slices/app/backbones/entries.js
@@ -84,16 +84,12 @@ var EntriesBackbone = $.extend(true, {}, GenericBackbone, {
                      value();
 
       fields = _.map(fields, function(key) {
-        var string;
-        if (key == 'name') {
-          string = "<td class='"+key+"'><a href='<%= url %>'><%= "+key+" %></a></td>"
-        } else if ( key != 'url' ) {
-          string = "<td class='"+key+"'><%= "+key+" %></td>";
-        }
-        return string;
+        return slices.entryTemplate(key);
       });
+
       fields.push("<td><a href='#' class='delete'>Delete</a></td>");
-      var template = _.template(fields.join(''));
+
+      var template = Handlebars.compile(fields.join(''));
       this.view_prototype = this.view_prototype.extend({template: template});
       this.collection.unbind('reset', this.set_view_template);
     },

--- a/app/assets/javascripts/slices/app/helpers/entries.js
+++ b/app/assets/javascripts/slices/app/helpers/entries.js
@@ -1,0 +1,41 @@
+slices.ENTRY_TEMPLATES = {
+  name: function(key) {
+    return '<td class="name"><a href="{{url}}">{{name}}</a></td>';
+  },
+
+  url: function(key) {
+    return null;
+  },
+
+  _default: function(key) {
+    return '<td class="{{' + key + '}}">{{' + key + '}}</td>';
+  }
+};
+
+
+/*
+ * Registers an entry template function for the given key.
+ * The function takes `key` and should return a string.
+ * Template compilation happens elsewhere.
+ *
+ * @param {String} key
+ * @param {Function} fun
+ */
+
+slices.registerEntryTemplate = function(key, fun) {
+  slices.ENTRY_TEMPLATES[key] = fun;
+}
+
+/*
+ * Returns the entry template for the given key.
+ *
+ * If not special templates are registered, the default
+ * template is returned.
+ *
+ * @return {String}
+ */
+
+slices.entryTemplate = function(key) {
+  var fun = slices.ENTRY_TEMPLATES[key] || slices.ENTRY_TEMPLATES['_default'];
+  return fun(key);
+}


### PR DESCRIPTION
Adds the ability to register custom templates for rows on the entries listing for set pages.

``` rb
# app/slices/foo_set/foo_presenter.rb
class FooPresenter < PagePresenter
  def self.columns
    {
      name: 'Name',
      view: 'View'
    }
  end

  def name
    @source.name
  end

  def view
    @source.path
  end
end
```

``` js
// app/assets/javascripts/admin.js
slices.registerEntryTemplate('view', function(key) {
  return '<td class="view"><a href="{{view}}">External link</a></td>';
});
```

This implementation depends on `key` being unique across the various sets an app may use. If necessary we could look at hierarchical namespacing i.e.

``` js
slices.registerEntryTemplate('view', function(key) {
  return '<td class="view"><a href="{{view}}">External link</a></td>';
});

slices.registerEntryTemplate('foo:view', function(key) {
  return '<td class="view"><a href="{{view}}">External link</a></td>';
});

slices.registerEntryTemplate('bar:view', function(key) {
  return '<td class="view"><a href="{{view}}">External link</a></td>';
});
```

Where entry templates for the `view` field would use `foo:view` in the `Foo` set, `bar:view` in the `Bar` set and `view` otherwise.
