### PR TITLE
Add hooks implementation

### DIFF
--- a/app/assets/javascripts/slices/app/helpers/hooks.js
+++ b/app/assets/javascripts/slices/app/helpers/hooks.js
@@ -1,0 +1,24 @@
+slices.HOOKS = {};
+
+/*
+ * Register a slices hook function.
+ *
+ * @param {String} key
+ * @param {Function} fun
+ */
+
+slices.on = function(key, fun) {
+  slices.HOOKS[key] = slices.HOOKS[key] || [];
+  slices.HOOKS[key].push(fun);
+};
+
+/*
+ * Trigger hooks for key.
+ *
+ * @param {String} key
+ */
+
+slices.trigger = function(key) {
+  var hooks = slices.HOOKS[key];
+  if (hooks) _.invoke(hooks, 'call');
+};

--- a/app/views/admin/entries/index.html.erb
+++ b/app/views/admin/entries/index.html.erb
@@ -28,5 +28,9 @@
 <% content_for :js_head do %>
 $(function() {
   EntriesBackbone.boot('<%= @page.id %>', <%= raw @options.to_json %>);
+  slices.trigger('entries:index');
+  <% @page.entry_types.each do |entry_type| %>
+    slices.trigger('entries:index:<%= entry_type %>');
+  <% end %>
 });
 <% end %>

--- a/app/views/admin/pages/show.html.erb
+++ b/app/views/admin/pages/show.html.erb
@@ -46,5 +46,8 @@
 
 <% content_for :js_head do %>
   <%= render "slices" %>
+  <script>
+    slices.trigger('pages:show');
+  </script>
 <% end %>
 


### PR DESCRIPTION
This patch provides mechanism to define hooks for the different areas of the admin UI.

It also adds two hooks to get started:
- `pages:show` triggered on the main page editor
- `entries:index` triggered on the entries index page

The entries page also triggers extra events for the page’s entry types. For example, when viewing the entries index for a set called **FooSet** `entries:index` will be triggered followed by `entries:index:foo`:

``` js
// app/assets/javascripts/admin.js
slices.on('entries:index', function() {
  // Do stuff that applies to all sets...
});

slices.on('entries:index:foo', function() {
  // Do stuff that applies only to the foo set...
});
```
