### PR TITLE
Increase capture delay and rerender on click

### DIFF
--- a/app/assets/javascripts/slices/app/views/token_field_view.js
+++ b/app/assets/javascripts/slices/app/views/token_field_view.js
@@ -24,7 +24,8 @@ slices.TokenFieldView = Backbone.View.extend({
     'keydown'       : 'onKey',
     'keypress'      : 'onKey',
     'click .del'    : 'onClickDel',
-    'click .option' : 'onClickOption'
+    'click .option' : 'onClickOption',
+    'click'         : 'onClick'
   },
 
   className: 'token-field',
@@ -101,7 +102,7 @@ slices.TokenFieldView = Backbone.View.extend({
 
   delayedCapture: _.debounce(function() {
     this.capture();
-  }, 750),
+  }, 1500),
 
   focusOrRemoveLastToken: function(e) {
     var focusedToken = this.$el.find('.token.focus');
@@ -196,6 +197,11 @@ slices.TokenFieldView = Backbone.View.extend({
       e.preventDefault();
       this.focusOrRemoveLastToken();
     }
+  },
+
+  onClick: function(e) {
+    this.render();
+    this.focus();
   },
 
   onClickDel: function(e) {

--- a/public/slices/templates/page_main.hbs
+++ b/public/slices/templates/page_main.hbs
@@ -2,4 +2,3 @@
   <label for="meta-name">Page Name</label>
   <input type="text" id="meta-name" name="meta-name" value="{{name}}">
 </li>
-


### PR DESCRIPTION
Render token field on every click to make sure the cursor is in the correct place. Previously, if the token field was offscreen (e.g. page meta), the padding-left could not be properly calculated.
