### PR TITLE
Add radio field helper

### DIFF
--- a/app/assets/javascripts/slices/app/helpers/radio_field.js
+++ b/app/assets/javascripts/slices/app/helpers/radio_field.js
@@ -1,0 +1,21 @@
+// Creates a radio field.
+//
+// Example:
+//
+//     {{#radioField field="example"}}
+//       <input type="radio" value="one">
+//       <input type="radio" value="two">
+//       <input type="radio" value="three">
+//     {{/radioField}}
+//
+Handlebars.registerHelper('radioField', function(options) {
+  var view = new slices.RadioFieldView({
+    id         : slices.fieldId(this, options.hash.field),
+    name       : options.hash.field,
+    value      : this[options.hash.field],
+    inner      : options.fn,
+    autoAttach : true
+  });
+
+  return new Handlebars.SafeString(view.placeholder());
+});

--- a/app/assets/javascripts/slices/app/views/radio_field_view.js
+++ b/app/assets/javascripts/slices/app/views/radio_field_view.js
@@ -1,0 +1,67 @@
+// Radio field
+//
+// This shouldn’t be instantiated directly.
+// Instead, use `{{radioField}}` like this:
+//
+//     {{#radioField field="example"}}
+//       <input type="radio" value="one">
+//       <input type="radio" value="two">
+//       <input type="radio" value="three">
+//     {{/radioField}}
+//
+slices.RadioFieldView = Backbone.View.extend({
+
+  // -- Config --
+
+  events: {
+    'change input[type="radio"]' : 'onChangeRadio'
+  },
+
+  className: 'radio-field',
+
+  template: Handlebars.compile(
+    '<div class="radio-options"></div>' +
+    '<input class="radio-value" type="hidden" name="{{name}}" value="{{value}}">'
+  ),
+
+  // -- Init --
+
+  initialize: function() {
+    _.bindAll(this);
+    this.name = this.options.name;
+    this.value = this.options.value;
+    this.inner = this.options.inner;
+    if (this.options.autoAttach) _.defer(this.attach);
+  },
+
+  // -- Rendering --
+
+  placeholder: function() {
+    return Handlebars.compile('<div id="placeholder-{{id}}"></div>')(this);
+  },
+
+  attach: function() {
+    $('#placeholder-' + this.id).replaceWith(this.el);
+    this.render();
+  },
+
+  render: function() {
+    var value = this.value;
+
+    $(this.el).html(this.template(this));
+    this.$('.radio-options').html(this.inner);
+    this.$('input[type="radio"]').each(function() {
+      if ($(this).val() == value) $(this).attr('checked', 'checked');
+    });
+
+    return this;
+  },
+
+  // -- Event Handlers --
+
+  onChangeRadio: function(event) {
+    this.value = event.target.value;
+    this.render();
+  }
+
+});

--- a/spec/dummy/app/slices/multiple_choice/multiple_choice_slice.rb
+++ b/spec/dummy/app/slices/multiple_choice/multiple_choice_slice.rb
@@ -1,0 +1,3 @@
+class MultipleChoiceSlice < Slice
+  field :answer, type: String
+end

--- a/spec/dummy/app/slices/multiple_choice/templates/multiple_choice.hbs
+++ b/spec/dummy/app/slices/multiple_choice/templates/multiple_choice.hbs
@@ -1,0 +1,8 @@
+<li>
+  <label for="slices-{{id}}-answer">What's the answer?</label>
+  {{#radioField field="answer"}}
+    <label><input type="radio" value="A">Yes</label>
+    <label><input type="radio" value="B">No</label>
+    <label><input type="radio" value="C">42</label>
+  {{/radioField}}
+</li>

--- a/spec/dummy/app/slices/multiple_choice/views/show.html.erb
+++ b/spec/dummy/app/slices/multiple_choice/views/show.html.erb
@@ -1,0 +1,1 @@
+<p>The answer is <%= slice.answer %></p>

--- a/spec/requests/admin/page/radio_field_spec.rb
+++ b/spec/requests/admin/page/radio_field_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe "The radio field", type: :request, js: true do
+  let! :home do
+    StandardTree.build_home
+  end
+
+  let! :slice do
+    home.slices << MultipleChoiceSlice.new(container: 'container_one')
+    home.slices.last
+  end
+
+  before do
+    sign_in_as_admin
+    visit admin_page_path home
+  end
+
+  it "lets me choose an option" do
+    selector = '.radio-field input[type="radio"]'
+
+    first(selector).click
+    click_on_save_changes
+
+    expect(page).to have_css(selector + '[value="A"]:checked')
+    expect(slice.reload.answer).to eq('A')
+  end
+end


### PR DESCRIPTION
This adds a radioField helper to make radio inputs easier to use. Previously radio inputs couldn't be used properly inside a composer or attachment composer.

``` hbs
{{#radioField field="choices"}}
  <input type="radio" value="yes">
  <input type="radio" value="no">
  <input type="radio" value="maybe">
{{/radioField}}
```

I used a block helper instead of `{{radioField field="choices" options="available_choices"}}` because it's more flexible for adding labels and other helper text.
