### PR TITLE
Make file upload work in old Safari and Internet Explorer

### DIFF
--- a/app/assets/javascripts/slices/app/helpers/uploader.js
+++ b/app/assets/javascripts/slices/app/helpers/uploader.js
@@ -43,7 +43,7 @@ $.extend(slices.Uploader.prototype, Backbone.Events, {
       type     : 'file',
       multiple : 'multiple',
       style    : 'position: absolute; visibility: hidden'
-    });
+    }).appendTo('body');
   },
 
   observeEvents: function() {


### PR DESCRIPTION
Safari 5 and IE9/10 only seem to trigger the upload dialog if the input is appended to the page.
