### PR TITLE
Allow sets to have entries restricted to a page

### DIFF
--- a/app/controllers/admin/entries_controller.rb
+++ b/app/controllers/admin/entries_controller.rb
@@ -59,7 +59,11 @@ class Admin::EntriesController < Admin::AdminController
   end
 
   def raw_entries
-    entry_class.entries
+    if set_slice.restrict_entries_to_page?
+      @page.entries(entry_type)
+    else
+      entry_class.entries
+    end
   end
 
   def sort_direction

--- a/app/models/set_slice.rb
+++ b/app/models/set_slice.rb
@@ -44,6 +44,10 @@ class SetSlice < Slice
     read_attribute(:sort_direction) || DEFAULT_SORT_DIRECTION
   end
 
+  def restrict_entries_to_page?
+    false
+  end
+
 
   private
 


### PR DESCRIPTION
This allows you to set a flag on a set slice, and have it only show entries that are also children of the set page. It addresses this issue: https://github.com/withassociates/slices/issues/23

If you think this implementation looks OK then I can write a test. Thoughts?