### PR TITLE
Fix definition of private class methods

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -176,23 +176,25 @@ class Page
     self.meta_description = value
   end
 
+  def self.parent_from_attributes(attributes)
+    if attributes.has_key?(:parent_path)
+      Page.find_by_path(attributes.delete(:parent_path))
+    elsif attributes.has_key?(:parent_id)
+      Page.find(attributes.delete(:parent_id))
+    else
+      attributes.delete(:parent)
+    end
+  end
+  private_class_method :parent_from_attributes
+
+  def self.page_exists?(path)
+    Page.find_by_path(path)
+  rescue NotFound
+    false
+  end
+  private_class_method :page_exists?
+
   private
-    def self.parent_from_attributes(attributes)
-      if attributes.has_key?(:parent_path)
-        Page.find_by_path(attributes.delete(:parent_path))
-      elsif attributes.has_key?(:parent_id)
-        Page.find(attributes.delete(:parent_id))
-      else
-        attributes.delete(:parent)
-      end
-    end
-
-    def self.page_exists?(path)
-      Page.find_by_path(path)
-    rescue NotFound
-      false
-    end
-
     def update_has_content
       self.has_content = slices.any?
       true # must be true otherwise save will fail

--- a/app/models/site_map.rb
+++ b/app/models/site_map.rb
@@ -8,8 +8,6 @@ class SiteMap
     '{root}'
   end
 
-  private
-
   def self.set_children_for(parent_id, data)
     parent = Page.find(parent_id)
     data.each_with_index do |child_data, i|
@@ -21,4 +19,5 @@ class SiteMap
       set_children_for(child_data['id'], child_data['children']) if child_data['children']
     end
   end
+  private_class_method :set_children_for
 end


### PR DESCRIPTION
I noticed that we had some class methods (I suspect I wrote this stuff originally) that were intended not to be part of their classes' public API, but that the Ruby used to make them private wasn't actually making them private.