### PR TITLE
Allow min and max values for composer fields

### DIFF
--- a/app/assets/javascripts/slices/app/helpers/composer.js
+++ b/app/assets/javascripts/slices/app/helpers/composer.js
@@ -17,6 +17,8 @@ Handlebars.registerHelper('composer', function(options) {
   var view = new slices.ComposerView({
     id         : slices.fieldId(this, options.hash.field),
     value      : this[options.hash.field],
+    min        : options.hash.min,
+    max        : options.hash.max,
     fields     : options.fn,
     addLabel   : options.hash.addLabel,
     autoAttach : true

--- a/app/assets/javascripts/slices/app/views/composer_view.js
+++ b/app/assets/javascripts/slices/app/views/composer_view.js
@@ -86,10 +86,26 @@ slices.ComposerView = Backbone.View.extend({
   },
 
   update: function() {
+    this.ensureMinAndMax();
+
     var value = this.collection.toJSON();
     this.$el.data('computed-value', value);
     this.$el[this.collection.isEmpty() ? 'removeClass' : 'addClass']('not-empty');
     if (this.broadcastChanges) this.$el.trigger('change');
+  },
+
+  ensureMinAndMax: function() {
+    var actions = this.$('.composer-actions');
+
+    if (this.collection.length < this.options.min) {
+      this.collection.add({});
+    }
+
+    if (this.collection.length >= this.options.max) {
+      actions.hide();
+    } else {
+      actions.show();
+    }
   },
 
   addItem: function(item, collection, options) {


### PR DESCRIPTION
This adds some options to the `composer` helper to enforce min and max number of items:

```hbs
{{#composer field="items" min="2" max="3"}}
  <textarea name="text" placeholder="Text…">{{text}}</textarea>
{{/composer}}
```

When a new slice is added:
![screen shot 2015-01-27 at 15 43 38](https://cloud.githubusercontent.com/assets/770763/5921380/6edf5d96-a63b-11e4-813d-fcb8a8ee132b.png)

When the maximum number of items is added:
![screen shot 2015-01-27 at 15 43 52](https://cloud.githubusercontent.com/assets/770763/5921384/7c324abc-a63b-11e4-981b-9e9155283bce.png)

