### PR TITLE
Fragment cache navigation helpers with page last changed timestamp

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -23,7 +23,7 @@ module NavigationHelper
   # @return [String]
   #
   def primary_navigation(id = 'primary_navigation')
-    cache 'page/navigation/' + id + '/' + @page.id.to_s do
+    cache cache_key_for_navigation(id) do
       benchmark 'Rendered primary_navigation' do
         nav = navigation(page: Page.home, depth: 1, id: id)
         safe_concat nav
@@ -48,11 +48,12 @@ module NavigationHelper
   #
   # @param  [Hash]       options
   # @option options [Integer] :depth (1)                    Number of levels to render
-  # @option options [Integer] :id ('secondary_navigation')  Id of surrounding UL
+  # @option options [String] :id ('secondary_navigation')  Id of surrounding UL
   # @return [String]
   #
   def secondary_navigation(options = {})
-    cache 'page/navigation/secondary/' + @page.id.to_s do
+    name = options.fetch('id') { 'secondary_navigation' }
+    cache cache_key_for_navigation(name) do
       benchmark 'Rendered secondary_navigation' do
         secondary_ancestors = (@page.ancestors[-2] || @page).navigable_children
         nav = if secondary_ancestors.empty? || @page.home?
@@ -190,6 +191,10 @@ module NavigationHelper
 
   def nav_list_identifier(page)
     page.home? ? 'nav-home' : ('nav' + page.path.gsub('/', '-'))
+  end
+
+  def cache_key_for_navigation(name)
+    ['pages', @page.id, name, Page.last_changed_at]
   end
 end
 

--- a/spec/models/page/last_update_spec.rb
+++ b/spec/models/page/last_update_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Page, type: :model do
+
+  describe "#update_last_changed_at" do
+    it "updates the last changed when a page is saved" do
+      page = Page.new(name: 'Page')
+      expect(page).to receive(:update_last_changed_at)
+      page.save
+    end
+
+    it "stores the last updated time in Rails.cache" do
+      Rails.cache.write(Page::LAST_CHANGED_AT_CACHE_KEY, 'not yet changed')
+      page = Page.new(name: 'Page')
+      page.save
+      expect(Rails.cache.read(Page::LAST_CHANGED_AT_CACHE_KEY)).to be_a(Integer)
+    end
+  end
+
+  describe ".last_changed_at" do
+    it "returns the value of the LAST_CHANGED_AT_CACHE_KEY" do
+      Rails.cache.write(Page::LAST_CHANGED_AT_CACHE_KEY, 123)
+      expect(Page.last_changed_at).to eq(123)
+    end
+
+    it "defaults to 0" do
+      Rails.cache.delete(Page::LAST_CHANGED_AT_CACHE_KEY)
+      expect(Page.last_changed_at).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
This will expire all navigation fragments when a page is changed thus
ensuring that the navigation will always be up to date. This is an
overzealous way of clearing the cache but this should suit the
general case.