### PR TITLE
Use bundled jQuery in admin interface

### DIFF
--- a/app/assets/javascripts/slices/slices.js
+++ b/app/assets/javascripts/slices/slices.js
@@ -1,5 +1,6 @@
 /*
  *= require_self
+ *= require slices/vendor/jquery
  *= require slices/vendor/rails
  *= require slices/vendor/handlebars
  *= require slices/vendor/underscore

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -6,7 +6,6 @@
   <title><%= cms_title %></title>
 
   <%= stylesheet_link_tag 'slices/slices' %>
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
   <%= javascript_include_tag 'slices/slices' %>
   <%= render "admin/shared/asset_storage" %>
 


### PR DESCRIPTION
I've been having trouble with the CDN version of jQuery in tests. Any reason we shouldn't be using the bundled version instead?