### PR TITLE
Allow multiple extra page templates

### DIFF
--- a/app/assets/javascripts/slices/app/slices.js
+++ b/app/assets/javascripts/slices/app/slices.js
@@ -55,13 +55,13 @@ var slices = {
 
       addSliceOptions(slices.availableSlices);
 
-      templates = [
+      templates = _.flatten([
         'slice',
         settings.mainTemplate,
         settings.metaTemplate,
-        settings.mainExtraTemplate,
-        settings.metaExtraTemplate
-      ];
+        settings.mainExtraTemplates,
+        settings.metaExtraTemplates
+      ]);
 
       loadSliceTemplates(pageId);
       loadTemplates(templates, pageId, loadPageModel);
@@ -317,13 +317,13 @@ var slices = {
 
       $('#page-meta').html(renderMetaFields(settings.metaTemplate));
 
-      if (settings.metaExtraTemplate) {
-        $('#page-meta').append(renderMetaFields(settings.metaExtraTemplate));
-      }
+      $.each(settings.metaExtraTemplates, function(i, template) {
+        $('#page-meta').append(renderMetaFields(template));
+      });
 
-      if (settings.mainExtraTemplate) {
-        $('#page-extra-main').html(renderMetaFields(settings.mainExtraTemplate));
-      }
+      $.each(settings.mainExtraTemplates, function(i, template) {
+        $('#page-extra-main').append(renderMetaFields(template));
+      });
 
       $('#page-meta-fields').applyDataValues().initDataPlugins();
 

--- a/app/presenters/page_presenter.rb
+++ b/app/presenters/page_presenter.rb
@@ -44,6 +44,14 @@ class PagePresenter < Presenter
     'page_meta_extra'
   end
 
+  def main_extra_templates
+    [main_extra_template]
+  end
+
+  def meta_extra_templates
+    [meta_extra_template]
+  end
+
   def breadcrumbs
     [@source] + @source.ancestors
   end

--- a/app/views/admin/pages/_slices.html.erb
+++ b/app/views/admin/pages/_slices.html.erb
@@ -9,8 +9,8 @@ $(function() {
       mainTemplate: '<%= @page.main_template %>',
       metaTemplate: '<%= @page.meta_template %>',
 
-      mainExtraTemplate: '<%= @page.main_extra_template %>',
-      metaExtraTemplate: '<%= @page.meta_extra_template %>',
+      mainExtraTemplates: <%= raw @page.main_extra_templates.to_json %>,
+      metaExtraTemplates: <%= raw @page.meta_extra_templates.to_json %>,
 
       super_user: <%= current_admin.super? %>,
 

--- a/lib/generators/slice/templates/presenter.rb
+++ b/lib/generators/slice/templates/presenter.rb
@@ -18,25 +18,24 @@ class <%= page_name.classify %>Presenter < PagePresenter
   end
 
 <%- if options.with_entry_templates? -%>
-  def main_extra_template
-    '<%= file_name %>/<%= page_name %>_main'
+  def main_extra_templates
+    super + ['<%= file_name %>/<%= page_name %>_main']
   end
 
-  def meta_extra_template
-    '<%= file_name %>/<%= page_name %>_meta'
+  def meta_extra_templates
+    super + ['<%= file_name %>/<%= page_name %>_meta']
   end
 <%- else -%>
-  # If you want to display extra information while editing or creating a
-  # page (i.e. in the admin UI's side bar) you'll need to define some
-  # .hbs files, and then tell the CMS to use them by uncommenting these
-  # methods.
+  # If you want to display extra information while editing a page you'll need
+  # to define some .hbs files, and then tell the CMS to use them by
+  # uncommenting these methods.
 
-  # def main_extra_template
-  #   '<%= file_name %>/<%= page_name %>_main'
+  # def main_extra_templates
+  #   super + ['<%= file_name %>/<%= page_name %>_main']
   # end
 
-  # def meta_extra_template
-  #   '<%= file_name %>/<%= page_name %>_meta'
+  # def meta_extra_templates
+  #   super + ['<%= file_name %>/<%= page_name %>_meta']
   # end
 <%- end -%>
 

--- a/spec/dummy/app/slices/project_set/project.rb
+++ b/spec/dummy/app/slices/project_set/project.rb
@@ -1,0 +1,12 @@
+class Project < Page
+  field :client, type: String
+  field :description, type: String
+
+  def entry?
+    true
+  end
+
+  def template
+    "project_set/views/show"
+  end
+end

--- a/spec/dummy/app/slices/project_set/project_presenter.rb
+++ b/spec/dummy/app/slices/project_set/project_presenter.rb
@@ -1,0 +1,18 @@
+class ProjectPresenter < PagePresenter
+  include EntryPresenter
+
+  @columns = {
+    name: 'Name',
+  }
+  class << self
+    attr_reader :columns
+  end
+
+  def main_extra_templates
+    ['project_set/project_main', 'project_set/project_more']
+  end
+
+  def name
+    @source.name.blank? ? "(name isn't set)" : @source.name
+  end
+end

--- a/spec/dummy/app/slices/project_set/project_set_slice.rb
+++ b/spec/dummy/app/slices/project_set/project_set_slice.rb
@@ -1,0 +1,3 @@
+class ProjectSetSlice < SetSlice
+  restricted_slice
+end

--- a/spec/dummy/app/slices/project_set/templates/project_main.hbs
+++ b/spec/dummy/app/slices/project_set/templates/project_main.hbs
@@ -1,0 +1,4 @@
+<li>
+  <label for="meta-description">Description</label>
+  <textarea id="meta-description" name="meta-description" placeholder="Description…" rows="2">{{description}}</textarea>
+</li>

--- a/spec/dummy/app/slices/project_set/templates/project_more.hbs
+++ b/spec/dummy/app/slices/project_set/templates/project_more.hbs
@@ -1,0 +1,4 @@
+<li>
+  <label for="meta-client">Client</label>
+  <input type="text" id="meta-client" name="meta-client" placeholder="Client…" value="{{client}}">
+</li>

--- a/spec/dummy/app/slices/project_set/templates/project_set.hbs
+++ b/spec/dummy/app/slices/project_set/templates/project_set.hbs
@@ -1,0 +1,4 @@
+<li>
+  <label for="slices-{{id}}-per_page">Per page</label>
+  <input type="text" id="slices-{{id}}-per_page" value="{{per_page}}">
+</li>

--- a/spec/dummy/app/slices/project_set/views/set.html.erb
+++ b/spec/dummy/app/slices/project_set/views/set.html.erb
@@ -1,0 +1,7 @@
+<%= will_paginate slice.page_entries, renderer: SetLinkRenderer, class: 'pagination above' %>
+<ul class="entries">
+  <% slice.page_entries.each do |entry| -%>
+    <li><%= link_to entry.name, entry.path %></li>
+  <% end -%>
+</ul>
+<%= will_paginate slice.page_entries, renderer: SetLinkRenderer, class: 'pagination below' %>

--- a/spec/generators/slice_generator_spec.rb
+++ b/spec/generators/slice_generator_spec.rb
@@ -299,12 +299,12 @@ describe "rails g slice example_set published_at:datetime --with-entry-templates
           attr_reader :columns
         end
 
-        def main_extra_template
-          'example_set/example_main'
+        def main_extra_templates
+          super + ['example_set/example_main']
         end
 
-        def meta_extra_template
-          'example_set/example_meta'
+        def meta_extra_templates
+          super + ['example_set/example_meta']
         end
 
         # The CMS needs to know how to present the data stored on a page;

--- a/spec/requests/admin/page/extra_templates_spec.rb
+++ b/spec/requests/admin/page/extra_templates_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe "A page with extra templates", type: :request, js: true do
+  before do
+    home = StandardTree.build_home
+    page = Project.make name: 'Example', parent: home
+    sign_in_as_admin
+    visit admin_page_path(page)
+  end
+
+  it "shows fields from all templates" do
+    expect(page).to have_css 'label', text: 'Description'
+    expect(page).to have_css 'label', text: 'Client'
+  end
+end


### PR DESCRIPTION
This allows us to define multiple 'extra' templates for page main and meta fields. The obvious use case is for some fields to be displayed on *all* pages and not get overridden by set-specific extra templates:

```ruby
# app/slices/article_set/article_presenter.rb

def main_extra_templates
  ['page_main_extra', 'article_set/article_main_extra']
end
```

I left the `main_extra_template` and `meta_extra_template` methods in place for backwards. Not sure whether to change [the generated presenter](https://github.com/withassociates/slices/blob/017067bb2457d26d3f49bd1c0cd2b22c9a6cc8f9/lib/generators/slice/templates/presenter.rb#L34-L39) too or leave as is.

Any thoughts/suggestions?