### PR TITLE
Fix duplication of main extras fields

### DIFF
--- a/app/assets/javascripts/slices/app/slices.js
+++ b/app/assets/javascripts/slices/app/slices.js
@@ -314,8 +314,8 @@ var slices = {
 
     function initMeta() {
       $('#page-main').html(renderMetaFields(settings.mainTemplate));
-
       $('#page-meta').html(renderMetaFields(settings.metaTemplate));
+      $('#page-extra-main').empty();
 
       $.each(settings.metaExtraTemplates, function(i, template) {
         $('#page-meta').append(renderMetaFields(template));


### PR DESCRIPTION
My previous [PR](https://github.com/withassociates/slices/pull/86) had a bug which caused main extra templates to be duplicated when the user saves the page. This fixes that bug by emptying the container before appending the templates.