### PR TITLE
Use Arial instead of Helvetica in admin interface

### DIFF
--- a/app/assets/stylesheets/slices/admin.css.erb
+++ b/app/assets/stylesheets/slices/admin.css.erb
@@ -3,7 +3,7 @@ html {
   overflow-y: scroll;
 }
 body {
-  font: 0.75em/1.2 Helvetica, Arial, sans-serif;
+  font: 0.75em/1.2 Arial, sans-serif;
   background-color: #fff;
   min-width: 860px;
   height: auto;
@@ -111,7 +111,7 @@ button,
 .button,
 .standard,
 .switcher li a {
-  font-family: Helvetica, Arial, sans-serif;
+  font-family: Arial, sans-serif;
   font-size: 12px;
   margin: 0;
 }
@@ -391,7 +391,7 @@ header ul li {
   line-height: 39px;
   font-size: 11px;
   color: #6b6b6b;
-  font-family: "Lucida Grande", Tahoma, Arial, Helvetica, sans-serif;
+  font-family: "Lucida Grande", Tahoma, Arial, sans-serif;
   text-shadow: 0 1px 0 rgba(0, 0, 0, 1);
 }
 header ul li a {
@@ -438,7 +438,7 @@ header nav ul li {
   margin: 0px;
   padding: 0px;
   margin-left: 0px;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: Arial, sans-serif;
 }
 header nav li a {
   display: inline-block;
@@ -495,7 +495,7 @@ header ul li,
   color: #696969;
   font-weight: normal;
   font-size: 11px;
-  font-family: "Lucida Grande", Arial, Helvetica, sans-serif;
+  font-family: "Lucida Grande", Arial, sans-serif;
   line-height: 38px;
   letter-spacing: 0px;
 }
@@ -1032,7 +1032,7 @@ form ul li.field-with-errors select {
   font-weight: normal;
   background-color: #EFEFEF;
   padding: 5px 0;
-  font-family: "Lucida Grande", Tahoma, Arial, Helvetica, sans-serif;
+  font-family: "Lucida Grande", Tahoma, Arial, sans-serif;
   padding-left: 15px;
 }
 .elements-table tr td {
@@ -1279,7 +1279,7 @@ a.remove-asset {
   border: 1px solid #D2D2D2;
   margin-bottom: 1em;
   padding: 0.5em;
-  font-family: "Lucida Grande", Tahoma, Arial, Helvetica, sans-serif;
+  font-family: "Lucida Grande", Tahoma, Arial, sans-serif;
   font-size: 11px;
   margin-top: 6px;
   width: 100%;
@@ -1289,7 +1289,7 @@ a.remove-asset {
   color: #696969;
   font-weight: normal;
   font-size: 11px;
-  font-family: "Lucida Grande", Arial, Helvetica, sans-serif;
+  font-family: "Lucida Grande", Arial, sans-serif;
 }
 .devise .login form p input[type='submit'] {
   width: 312px;
@@ -1303,7 +1303,7 @@ a.remove-asset {
   color: #696969;
   font-weight: normal;
   font-size: 11px;
-  font-family: "Lucida Grande", Arial, Helvetica, sans-serif;
+  font-family: "Lucida Grande", Arial, sans-serif;
 }
 
 /*SPECIFIC TO It's Nice That*/
@@ -1318,7 +1318,7 @@ a.remove-asset {
 .livefield-results,
 .livefield-result {
   color: #565656;
-  font: 13px/1 Helvetica, Arial, sans-serif;
+  font: 13px/1 Arial, sans-serif;
 }
 .livefield-input {
 


### PR DESCRIPTION
Chrome has been rendering Helvetica (top) badly for a while (see squashed line spacing and token field edge). Arial (bottom) seems to render better.

![helvetica-vs-arial](https://cloud.githubusercontent.com/assets/770763/7133865/60496fa2-e28f-11e4-914d-040509e3a220.png)