### PR TITLE
Stop persisting supporting page admin data

### DIFF
--- a/app/assets/javascripts/slices/app/models/page.js
+++ b/app/assets/javascripts/slices/app/models/page.js
@@ -97,8 +97,6 @@ slices.model.Page = (
       });
 
       _.each(pageData.slices, function (slice) {
-        // Remove the client id which the backend returns even after a successfully created new slice
-        delete slice.client_id;
         delete slice._new;
 
         try {

--- a/app/assets/javascripts/slices/app/models/page.js
+++ b/app/assets/javascripts/slices/app/models/page.js
@@ -36,9 +36,9 @@ slices.model.Page = (
           slice.client_id = slice.id;
           slice._new = 1;
           delete slice.id;
-          delete slice.template;
-          delete slice.name;
         }
+        delete slice.template;
+        delete slice.name;
       });
 
       /* Strip these out of the returned JSON object, only values

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -144,6 +144,8 @@ class Page
   def update_attributes(attributes)
     attributes = attributes.symbolize_keys
 
+    attributes.delete(:available_layouts)
+
     unless home?
       if attributes.has_key?(:name) || attributes.has_key?(:permalink)
         new_path = self.class.path_from_attributes(attributes, parent)

--- a/app/models/slice.rb
+++ b/app/models/slice.rb
@@ -9,7 +9,7 @@ class Slice
   embedded_in :normal_page, class_name: 'Page', inverse_of: :slices
   embedded_in :set_page, inverse_of: :set_slices
 
-  attr_accessor :renderer, :current_page
+  attr_accessor :renderer, :current_page, :client_id
   alias :page :current_page
 
   def self.restricted_slice
@@ -68,12 +68,8 @@ class Slice
     end
   end
 
-  def client_id?
-    attributes.include?('client_id')
-  end
-
   def id_or_client_id
-    client_id? ? client_id : id
+    client_id.presence || id
   end
 
   def to_delete?
@@ -103,7 +99,7 @@ class Slice
   def as_json(*args)
     attributes.symbolize_keys.except(:_id, :_type).tap do |result|
       result.merge!(id: id, type: type)
-      result.merge!(client_id: client_id) if client_id? && new_record?
+      result.merge!(client_id: client_id) if client_id && new_record?
 
       self.embedded_relations.each do |field, metadata|
         result.merge!(field.to_sym => send(field).map(&:as_json))

--- a/app/models/slice.rb
+++ b/app/models/slice.rb
@@ -72,10 +72,6 @@ class Slice
     client_id.presence || id
   end
 
-  def to_delete?
-    attributes.include?('_deleted')
-  end
-
   def write_attributes(attrs)
     attrs = attrs.symbolize_keys
     self.embedded_relations.each do |field, metadata|

--- a/lib/slices/has_slices.rb
+++ b/lib/slices/has_slices.rb
@@ -70,7 +70,7 @@ module Slices
     def slice_errors_for(embed_name)
       Hash.new.tap do |message|
         slices_for(embed_name).each do |slice|
-          if ! slice.valid? && ! slice.to_delete?
+          if ! slice.valid?
             message[slice.id_or_client_id] = messages_from_errors(slice.errors)
           end
         end

--- a/lib/slices/has_slices.rb
+++ b/lib/slices/has_slices.rb
@@ -35,11 +35,13 @@ module Slices
           next if slice_attributes[:_destroy]
           slice_attributes.delete :_new
           slice_type = slice_attributes.delete :type
+          client_id = slice_attributes.delete :client_id
           (slice_type + '_slice').
             camelize.
             constantize.
             new(slice_attributes).tap do |s|
               s.id = slice_attributes[:id] if slice_attributes[:id].present?
+              s.client_id = client_id
             end
         }.compact
       end

--- a/lib/slices/has_slices.rb
+++ b/lib/slices/has_slices.rb
@@ -34,7 +34,8 @@ module Slices
           slice_attributes = slice_attributes.symbolize_keys
           next if slice_attributes[:_destroy]
           slice_attributes.delete :_new
-          (slice_attributes[:type] + '_slice').
+          slice_type = slice_attributes.delete :type
+          (slice_type + '_slice').
             camelize.
             constantize.
             new(slice_attributes).tap do |s|

--- a/spec/apis/pages/update_spec.rb
+++ b/spec/apis/pages/update_spec.rb
@@ -5,12 +5,6 @@ shared_examples "updates slices correctly" do
     expect(json_slices.find { |slice| slice['id'] == @deleted_slice_id }).to be_nil
   end
 
-  it "keeps client_id on new slices" do
-    container_one_slices, new_slice = container_one_slices_and_new_slice
-
-    expect(new_slice['client_id']).to eq 'new_123'
-  end
-
   it "removes _new from new slices" do
     container_one_slices, new_slice = container_one_slices_and_new_slice
 
@@ -206,6 +200,10 @@ describe "PUT to pages#update" do
 
     it "has errors on page document" do
       expect(json_response).to include({'name' => ["can't be blank"]})
+    end
+
+    it "keeps client_id on new slices" do
+      expect(json_errors['new_123']).to be
     end
 
     it "has errors on slices" do

--- a/spec/apis/pages/update_spec.rb
+++ b/spec/apis/pages/update_spec.rb
@@ -40,25 +40,18 @@ describe "PUT to pages#update" do
 
   def new_slideshow_slice
     slide = {
-      'position'    => 0,
       'asset_id'    => '4f0ead1cf622394081000004',
-      'asset_url'   => '/system/files/012012/4f0ead1cf622394081000004/admin/CIMG0565.JPG?1326361883'
+      'caption'     => '',
     }
 
     {
       'client_id'   => 'new_124',
       '_new'        => 1,
       'type'        => 'slideshow',
-      'name'        => 'Slideshow',
       'position'    => 0,
       'container'   => 'container_one',
 
       'slides'      => [ slide ],
-
-      'attachments' => '',
-      'asset_url'   => '',
-      'fileView'    => '',
-      'caption'     => '',
     }
   end
 

--- a/spec/dummy/app/slices/article_set/article.rb
+++ b/spec/dummy/app/slices/article_set/article.rb
@@ -47,5 +47,16 @@ class Article < Page
     )
   end
 
+  def update_attributes(attrs)
+    %w(
+      available_tags
+      available_categories
+      images
+    ).each do |key|
+      attrs.delete(key)
+    end
+    super
+  end
+
 end
 

--- a/spec/dummy/config/mongoid.yml
+++ b/spec/dummy/config/mongoid.yml
@@ -1,3 +1,6 @@
+mongoid_options: &mongoid_options
+  allow_dynamic_fields: false
+
 development:
   sessions:
     default:
@@ -7,43 +10,7 @@ development:
       options:
         safe: true
   options:
-    # Configuration for whether or not to allow access to fields that do
-    # not have a field definition on the model. (default: true)
-    # allow_dynamic_fields: true
-
-    # Enable the identity map, needed for eager loading. (default: false)
-    # identity_map_enabled: false
-
-    # Includes the root model name in json serialization. (default: false)
-    # include_root_in_json: false
-
-    # Include the _type field in serializaion. (default: false)
-    # include_type_for_serialization: false
-
-    # Preload all models in development, needed when models use
-    # inheritance. (default: false)
-    # preload_models: false
-
-    # Protect id and type from mass assignment. (default: true)
-    # protect_sensitive_fields: true
-
-    # Raise an error when performing a #find and the document is not found.
-    # (default: true)
-    # raise_not_found_error: true
-
-    # Raise an error when defining a scope with the same name as an
-    # existing method. (default: false)
-    # scope_overwrite_exception: false
-
-    # Skip the database version check, used when connecting to a db without
-    # admin access. (default: false)
-    # skip_version_check: false
-
-    # User Active Support's time zone in conversions. (default: true)
-    # use_activesupport_time_zone: true
-
-    # Ensure all times are UTC in the app side. (default: false)
-    # use_utc: false
+    <<: *mongoid_options
 test:
   sessions:
     default:
@@ -54,3 +21,5 @@ test:
         safe: true
         max_retries: 1
         retry_interval: 0
+  options:
+    <<: *mongoid_options

--- a/spec/models/slice/as_json_spec.rb
+++ b/spec/models/slice/as_json_spec.rb
@@ -4,7 +4,7 @@ describe Slice, type: :model do
   describe "#as_json" do
 
     let :slice do
-      Slice.new(title: 'Title',
+      TitleSlice.new(title: 'Title',
                 container: 'container_one',
                 position: 0,
                 client_id: 'new1')

--- a/spec/models/slice/as_json_spec.rb
+++ b/spec/models/slice/as_json_spec.rb
@@ -26,8 +26,9 @@ describe Slice, type: :model do
     end
 
     it "uses client_id if the slice is new" do
-      new_slice = Slice.new(client_id: 'new_123').as_json
-      expect(new_slice[:client_id]).to eq 'new_123'
+      new_slice = Slice.new
+      new_slice.client_id = 'new_123'
+      expect(new_slice.as_json[:client_id]).to eq 'new_123'
     end
 
   end

--- a/spec/models/slice/general_spec.rb
+++ b/spec/models/slice/general_spec.rb
@@ -15,15 +15,5 @@ describe Slice, type: :model do
     end
   end
 
-  context "marked as deleted" do
-    let :slice do
-      Slice.new('_deleted' => true)
-    end
-
-    it "is deleteable" do
-      expect(slice).to be_to_delete
-    end
-  end
-
 end
 


### PR DESCRIPTION
I had a hard time giving this a title, but basically we send supporting data to/from the client _inside_ the page json, which means it ends up getting persisted in the database. This means (a) we store a load of stuff we don't need to and (b) we can't turn off Mongoid dynamic fields (because obviously there are no fields defined for this data).

Currently this branch just deletes on the way back the data that was inserted on the way out. Pretty hacky. I'm not really convinced it's good enough to go in, but maybe it's an ok stopgap. There are better solutions, but needs more discussion, so this PR can be the start of it.
