### PR TITLE
Remove some references to long-unused `site_id`

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -25,7 +25,7 @@ class Admin
 
   text_search_in :name, :email
 
-  validates_uniqueness_of :email, case_sensitive: false, scope: :site_id
+  validates_uniqueness_of :email, case_sensitive: false
   validates_presence_of :encrypted_password
 
   devise :database_authenticatable, :recoverable, :rememberable,

--- a/lib/slices/page_as_json.rb
+++ b/lib/slices/page_as_json.rb
@@ -4,7 +4,7 @@ module Slices
     def as_json(options = {})
       options ||= {}
 
-      hash = attributes.symbolize_keys.except(:_id, :_type, :_keywords, :set_slices, :site_id).merge(
+      hash = attributes.symbolize_keys.except(:_id, :_type, :_keywords, :set_slices).merge(
         id:        id,
         permalink: permalink,
         slices:    ordered_slices_for(options[:slice_embed]).map {|slice| slice.as_json },


### PR DESCRIPTION
I assume this was accidentally left when the "multisite" stuff was removed.