### PR TITLE
Ensure slices are never rendered with a layout

### DIFF
--- a/lib/slices/renderer.rb
+++ b/lib/slices/renderer.rb
@@ -27,8 +27,8 @@ module Slices
       render_slices slices.where(container: container)
     end
 
-    def render_to_string(*args)
-      @controller.render_to_string(*args)
+    def render_to_string(template, options)
+      @controller.render_to_string(template, { layout: nil }.merge(options))
     end
 
     def fragment_exist?(cache_key)


### PR DESCRIPTION
In some projects we have occasionally been seeing a "stack level too deep" exception. I have determined the cause is having controllers which declare their own `layout` (in the normal Rails way). (For normal Slices pages there is no need to declare a layout like that because it comes from the page, but in some projects we have controllers which render a mixture of Slices and non-Slices pages, and so a layout is required for the latter.)

What happens is that the layout is rendered, which calls [`PagesHelper#container`](https://github.com/withassociates/slices/blob/master/app/helpers/pages_helper.rb#L21), which ends up calling [`Slices::Renderer#render_to_string`](https://github.com/withassociates/slices/blob/master/lib/slices/renderer.rb#L30). Then if you follow it through the Rails stack you see it finds the controller's layout again and tries to render it, which takes us back to `PagesHelper#container` again - that's the loop.

It seems like you can stop it from finding the layout again by passing an explicit `layout: nil` when the slice is rendered, but I am not familiar with Slices internals (e.g. I don't know why we hooked into the controller's `render_to_string` method in the first place) so can't really tell if this makes sense or not. I can continue to investigate but I thought now was a good time to throw it open to everyone else in case someone can shed some light on it. Over to you...