### PR TITLE
Use existing Rails app config when deciding whether to show exceptions or not

### DIFF
--- a/app/controllers/slices_controller.rb
+++ b/app/controllers/slices_controller.rb
@@ -11,7 +11,7 @@ class SlicesController < ActionController::Base
   define_callbacks :render_page, terminator: :response_body
 
   def self.should_raise_exceptions?
-    ! Rails.env.production?
+    Rails.application.config.consider_all_requests_local
   end
 
   protected


### PR DESCRIPTION
It bothers me that staging envs (where we have them) don't behave the same as production in this respect. I remembered that Rails already has the notion of whether to show errors or not, so why not reuse it here?