### PR TITLE
[WIP] Assets have a separate Thumbnail

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -4,6 +4,9 @@ class Asset
   include MongoSearch::Searchable
   include Mongoid::Paperclip
 
+  embeds_one :thumbnail, class_name: "Asset", cyclic: true
+  embedded_in :parent_asset, class_name: "Asset", cyclic: true
+
   IMAGE_REGEX = /(jpg|jpeg|gif|png)/
   NORMALIZED_EXTENSIONS = { ".jpeg" => ".jpg" }
 

--- a/spec/models/asset/paperclip_spec.rb
+++ b/spec/models/asset/paperclip_spec.rb
@@ -8,6 +8,13 @@ describe Asset, type: :model do
       Asset.make file: file_fixture
     end
 
+    let :asset_with_thumbnail do
+      a = Asset.make(file: file_fixture)
+      a.thumbnail = Asset.make(file: file_fixture)
+      a.save
+      a
+    end
+
     let :pdf_asset do
       Asset.make file: file_fixture('test.pdf')
     end
@@ -36,6 +43,40 @@ describe Asset, type: :model do
 
       it "stores the admin dimensions" do
         expect(asset.file_dimensions).to include 'admin' => '180x180'
+      end
+
+    end
+
+    context "on creating an image asset with a separate thumbnail" do
+
+      it "stores the file type" do
+        expect(asset_with_thumbnail.file_content_type).to eq 'image/jpeg'
+        expect(asset_with_thumbnail.thumbnail.file_content_type).to eq 'image/jpeg'
+      end
+
+      it "stores the file size" do
+        expect(asset_with_thumbnail.file_file_size).to eq 5545
+        expect(asset_with_thumbnail.thumbnail.file_file_size).to eq 5545
+      end
+
+      it "stores the fingerprint" do
+        expect(asset_with_thumbnail.file_fingerprint).to eq 'ca05197526f33a39b871bd5eda640182'
+        expect(asset_with_thumbnail.thumbnail.file_fingerprint).to eq 'ca05197526f33a39b871bd5eda640182'
+      end
+
+      it "generates an admin thumbnail for the uploaded file" do
+        expect(asset_with_thumbnail.file).to be_exists(:admin)
+        expect(asset_with_thumbnail.thumbnail.file).to be_exists(:admin)
+      end
+
+      it "does not generate the extended style for the uploaded file" do
+        expect(asset_with_thumbnail.file).to_not be_exists(:extended)
+        expect(asset_with_thumbnail.thumbnail.file).to_not be_exists(:extended)
+      end
+
+      it "stores the admin dimensions" do
+        expect(asset_with_thumbnail.file_dimensions).to include 'admin' => '180x180'
+        expect(asset_with_thumbnail.thumbnail.file_dimensions).to include 'admin' => '180x180'
       end
 
     end


### PR DESCRIPTION
Hey, all.

This has arisen on a couple of projects, but it's more pressing on an upcoming one, so after some chatting with Mathew, Jamie and Tom, there's a movement to add a 'thumbnail' to an `Asset`.

The use case of this is where you would like the thumbnail of an image to be beyond the scope of what Paperclip can do, compositionally.

The first commit I've pushed here adds a `has_one` to `Asset` - a recursive relationship, as seen here: http://www.rubydoc.info/github/mongoid/mongoid/master/Mongoid%2FRelations%2FCyclic%2FClassMethods%3Arecursively_embeds_one (I didn't use the `recursively_embeds_one` helper, because the resulting `child_asset` method is a bit undesirable).

Wanted to put this out to all y'all and get this one moving, as the aforementioned project is looming.

Work yet to do:
- [ ] Add UI for adding a `Thumbnail` to an existing `Asset` 