### PR TITLE
Remove google auth from config

### DIFF
--- a/lib/generators/slices/templates/slices.rb
+++ b/lib/generators/slices/templates/slices.rb
@@ -3,11 +3,6 @@
 #   avatar:           '30x30#',
 # )
 
-# Configure the Google Apps domain to use for quick auth.
-# Press the '=' key on the admin sign-in screen to authenticate via
-# a Google Apps account within the domain configured here.
-# Slices::Config.google_apps_domain = 'example.com'
-
 # Configure templates for new page fields and page actions
 # Slices::Config.page_fields_template = 'slices/page_fields'
 # Slices::Config.page_actions_template = 'slices/page_actions'

--- a/lib/slices/config.rb
+++ b/lib/slices/config.rb
@@ -57,20 +57,6 @@ module Slices
       }
     end
 
-    # Google Apps domain for quick auth.
-    #
-    # @return [String] the domain
-    def self.google_apps_domain
-      @google_apps_domain
-    end
-
-    # Set Google Apps domain for quick auth.
-    #
-    # @param [String] the domain
-    def self.google_apps_domain=(domain)
-      @google_apps_domain = domain
-    end
-
     # Page fields template path.
     #
     # @return [String] the path


### PR DESCRIPTION
Stopped being used when we removed the omniauth stuff in 81b8b11022645bb871a1ca5f5bf2c087705f1af2.