### PR TITLE
Run travis build against latest ruby 2.1 and 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.0.0
   - 2.1.0
 before_install:
+  - "gem update bundler"
   - "rm Gemfile.lock"
 bundler_args: --without development --jobs 3 --retry 3
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1.7
+  - 2.2.3
 before_install:
   - "gem update bundler"
   - "rm Gemfile.lock"

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'database_cleaner', '~> 0.9.1'
 gem 'rspec-rails', '~> 3.2.0'
 gem 'poltergeist'
 gem 'ammeter'
+gem 'test-unit', platforms: [:ruby_22]
 
 group :development do
   gem 'byebug', platforms: [:ruby_20, :ruby_21]

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'ammeter'
 gem 'test-unit', platforms: [:ruby_22]
 
 group :development do
-  gem 'byebug', platforms: [:ruby_20, :ruby_21]
+  gem 'byebug', platforms: [:ruby_20, :ruby_21, :ruby_22]
   gem 'debugger', platforms: [:ruby_19]
   gem 'pry-rails', '~> 0.2.2'
   gem 'launchy', '~> 2.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,7 @@ DEPENDENCIES
   pry-rails (~> 0.2.2)
   rspec-rails (~> 3.2.0)
   slices!
+  test-unit
 
 BUNDLED WITH
    1.10.6


### PR DESCRIPTION
Depends on https://github.com/withassociates/slices/pull/120.

Copied from https://github.com/rails/rails/blob/4-2-stable/.travis.yml#L22 (except I don't think we care about `ruby-head`).