### PR TITLE
Test against latest versions of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+before_install:
+  - "rm Gemfile.lock"
 script: bundle exec rspec spec --tag ~ci:false --color
 services:
   - mongodb

--- a/spec/lib/slices/asset/rename_spec.rb
+++ b/spec/lib/slices/asset/rename_spec.rb
@@ -38,8 +38,8 @@ describe 'Slices::Asset::Rename' do
         fog_directory: 'directory',
         fog_credentials: {
           provider: 'AWS',
-          aws_access_key_id: :aws_access_key_id,
-          aws_secret_access_key: :aws_secret_access_key,
+          aws_access_key_id: 'aws_access_key_id',
+          aws_secret_access_key: 'aws_secret_access_key',
         },
       })
 


### PR DESCRIPTION
This is so we test against the latest possible versions of dependencies, so we find breakages sooner.