### PR TITLE
Update generator specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ end
 
 group :test do
   gem 'launchy',          '~> 2.1.2'
-  gem 'genspec'
+  gem 'ammeter'
 end
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,10 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.3.5)
+    ammeter (1.1.2)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-rails (>= 2.2)
     arel (3.0.3)
     bcrypt (3.1.7)
     bcrypt-ruby (3.1.5)
@@ -92,10 +96,6 @@ GEM
       nokogiri (~> 1.5)
       ruby-hmac
     formatador (0.2.4)
-    genspec (0.2.8)
-      rspec (~> 2)
-      sc-core-ext (~> 1.2.1)
-      thor
     highline (1.6.21)
     hike (1.2.3)
     i18n (0.6.9)
@@ -172,10 +172,6 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redcarpet (3.0.0)
-    rspec (2.99.0)
-      rspec-core (~> 2.99.0)
-      rspec-expectations (~> 2.99.0)
-      rspec-mocks (~> 2.99.0)
     rspec-collection_matchers (1.0.0)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (2.99.0)
@@ -197,8 +193,6 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    sc-core-ext (1.2.1)
-      activesupport (>= 2.3.5)
     slop (3.4.7)
     sprockets (2.2.2)
       hike (~> 1.2)
@@ -226,6 +220,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ammeter
   bundler
   byebug
   capybara (~> 2.3.0)
@@ -233,7 +228,6 @@ DEPENDENCIES
   debugger
   escape_utils (~> 0.2.4)
   fog
-  genspec
   jquery-rails (~> 2.1.4)
   launchy (~> 2.1.2)
   poltergeist

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,3 +242,6 @@ DEPENDENCIES
   sass-rails (~> 3.2.5)
   slices!
   uglifier (~> 1.3.0)
+
+BUNDLED WITH
+   1.10.6

--- a/lib/generators/slices/install_generator.rb
+++ b/lib/generators/slices/install_generator.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'rails/generators'
 require 'thor'
 

--- a/slices.gemspec
+++ b/slices.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 require File.expand_path('../lib/slices/version', __FILE__)
 
 Gem::Specification.new do |s|

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -1,25 +1,33 @@
 require 'spec_helper'
+require 'generators/slices/install_generator'
 
-describe "slices:install" do
+describe Slices::InstallGenerator do
+  destination Rails.root.join('tmp')
+
+  before do
+    prepare_destination
+    run_generator
+  end
+
   it "should create an app/slices directory" do
-    expect(subject).to generate("app/slices/")
+    expect(file("app/slices/")).to exist
   end
 
   it "should create a Slices initializer" do
-    expect(subject).to generate("config/initializers/slices.rb")
+    expect(file("config/initializers/slices.rb")).to exist
   end
 
   it "should create an application layout" do
-    expect(subject).to generate("app/views/layouts/default.html.erb")
+    expect(file("app/views/layouts/default.html.erb")).to exist
   end
 
   it "should delete public/index.html" do
-    expect(File).to_not be_exist('public/index.html')
+    expect(file('public/index.html')).not_to exist
   end
 
   it "should create admin nav partials" do
-    expect(subject).to generate("app/views/admin/shared/_custom_navigation.html.erb")
-    expect(subject).to generate("app/views/admin/shared/_custom_links.html.erb")
+    expect(file("app/views/admin/shared/_custom_navigation.html.erb")).to exist
+    expect(file("app/views/admin/shared/_custom_links.html.erb")).to exist
   end
 end
 

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require 'spec_helper'
 
 describe "slices:install" do

--- a/spec/generators/slice_generator_spec.rb
+++ b/spec/generators/slice_generator_spec.rb
@@ -1,389 +1,378 @@
 # -*- encoding: utf-8 -*-
 
 require 'spec_helper'
+require 'generators/slice/slice_generator'
 
-describe "rails g slice example" do
+describe SliceGenerator do
+  destination Rails.root.join('tmp')
+
   before do
-    run_generator "slice example"
+    prepare_destination
   end
 
-  after do
-    FileUtils.rm_rf "app/slices/example"
+  describe "rails g slice example" do
+    before do
+      run_generator %w(example)
+    end
+
+    it "creates example_slice.rb" do
+      expect(file("app/slices/example/example_slice.rb")).to contain <<-CONTENT
+        class ExampleSlice < Slice
+          # For each field that you want to store on the slice, declare the
+          # field as follow:
+          # field :title
+          # field :body
+          #
+          # You can also specify more complex fields like this:
+          # field :potatoes, type: Array, default: []
+          #
+          # For date/time fields use the following convention:
+          # field :published_on, type: Date
+          # field :published_at, type: DateTime
+          #
+          # For more details of available fields, see the Mongoid
+          # documentation: http://mongoid.org/docs/documents/fields.html
+          #
+          # You can also attach assets to a slice, like this:
+          # has_attachments
+          #
+          # You can name your attachments like this:
+          # has_attachments :images
+          #
+          # You can map your attachments to a custom class like this:
+          # class Image < Attachment
+          #   field :caption
+          # end
+          # has_attachments :images, class_name: "MySlice::Image"
+        end
+      CONTENT
+    end
+
+    it "creates templates/example.hbs" do
+      expect(file("app/slices/example/templates/example.hbs")).to exist
+    end
+
+    it "creates views/show.html.erb" do
+      expect(file("app/slices/example/views/show.html.erb")).to contain <<-CONTENT
+        <div class="slice example">
+
+          <!--
+            Stick the HTML that should be rendered when your slice is displayed here.
+
+            You can refer to data stored on your slice by calling slice.foo inside
+            a normal ERB code block.
+          -->
+
+          <p>Change me by editing app/slices/example/views/show.html.erb</p>
+
+        </div>
+      CONTENT
+    end
   end
 
-  it "creates example_slice.rb" do
-    expect("app/slices/example/example_slice.rb").to contain <<-CONTENT
-      class ExampleSlice < Slice
-        # For each field that you want to store on the slice, declare the
-        # field as follow:
-        # field :title
-        # field :body
-        #
-        # You can also specify more complex fields like this:
-        # field :potatoes, type: Array, default: []
-        #
-        # For date/time fields use the following convention:
-        # field :published_on, type: Date
-        # field :published_at, type: DateTime
-        #
-        # For more details of available fields, see the Mongoid
-        # documentation: http://mongoid.org/docs/documents/fields.html
-        #
-        # You can also attach assets to a slice, like this:
-        # has_attachments
-        #
-        # You can name your attachments like this:
-        # has_attachments :images
-        #
-        # You can map your attachments to a custom class like this:
-        # class Image < Attachment
-        #   field :caption
-        # end
-        # has_attachments :images, class_name: "MySlice::Image"
-      end
-    CONTENT
-  end
+  describe "rails g slice example title:string images:attachments featured_at:date_time confirmed:boolean description:text" do
+    before do
+      run_generator %w(example title:string images:attachments featured_at:date_time confirmed:boolean description:text)
+    end
 
-  it "creates templates/example.hbs" do
-    expect("app/slices/example/templates/example.hbs").to exist
-  end
+    it "creates example_slice.rb" do
+      expect(file("app/slices/example/example_slice.rb")).to contain <<-CONTENT
+        include Slices::HasAttachments
+        field :title, type: String
+        class Image < Attachment
+          # Extend your attachments by adding fields here e.g.
+          field :caption
+        end
+        has_attachments :images, class_name: 'ExampleSlice::Image'
+        field :featured_at, type: DateTime
+        field :confirmed,   type: Boolean
+        field :description, type: String
+      CONTENT
+    end
 
-  it "creates views/show.html.erb" do
-    expect("app/slices/example/views/show.html.erb").to contain <<-CONTENT
-      <div class="slice example">
+    it "creates templates/example.hbs" do
+      expect(file("app/slices/example/templates/example.hbs")).to contain <<-CONTENT
+        <li>
+          <label for="slices-{{id}}-title">Title</label>
+          <input type="text" id="slices-{{id}}-title" placeholder="Title…" value="{{title}}">
+        </li>
+        <li>
+          <label for="slices-{{id}}-images">Images</label>
+          {{#attachmentComposer field="images"}}
+            <textarea name="caption" placeholder="Caption…" class="full-height">{{caption}}</textarea>
+          {{/attachmentComposer}}
+        </li>
+        <li>
+          <label for="slices-{{id}}-featured_at">Featured at</label>
+          {{dateField field="featured_at"}}
+        </li>
+        <li>
+          <label>
+            <input type="checkbox" id="slices-{{id}}-confirmed" data-value="{{confirmed}}">
+            Confirmed
+          </label>
+        </li>
+        <li>
+          <label for="slices-{{id}}-description">Description</label>
+          <textarea id="slices-{{id}}-description" placeholder="Description…" rows="24">{{description}}</textarea>
+        </li>
 
         <!--
-          Stick the HTML that should be rendered when your slice is displayed here.
+          To change the text that is displayed when this slice is minimised,
+          use the `slicePreview` helper below. The method is scoped to this slice
+          so you can easily access any contained elements.
 
-          You can refer to data stored on your slice by calling slice.foo inside
-          a normal ERB code block.
+          Examples:
+
+            return this.find('textarea').val();
+            return this.find('option:selected').text();
+
         -->
+        {{#slicePreview}}
+        {{/slicePreview}}
 
-        <p>Change me by editing app/slices/example/views/show.html.erb</p>
+      CONTENT
+    end
 
-      </div>
-    CONTENT
-  end
-end
+    it "creates views/show.html.erb" do
+      expect(file("app/slices/example/views/show.html.erb")).to contain <<-CONTENT
+        <div class="slice example">
 
-describe "rails g slice example title:string images:attachments featured_at:date_time confirmed:boolean description:text" do
-  before do
-    run_generator "slice example title:string images:attachments featured_at:date_time confirmed:boolean description:text"
-  end
+          <!--
+            Stick the HTML that should be rendered when your slice is displayed here.
 
-  after do
-    FileUtils.rm_rf "app/slices/example"
-  end
+            You can refer to data stored on your slice by calling slice.foo inside
+            a normal ERB code block.
+          -->
 
-  it "creates example_slice.rb" do
-    expect("app/slices/example/example_slice.rb").to contain <<-CONTENT
-      include Slices::HasAttachments
-      field :title, type: String
-      class Image < Attachment
-        # Extend your attachments by adding fields here e.g.
-        field :caption
-      end
-      has_attachments :images, class_name: 'ExampleSlice::Image'
-      field :featured_at, type: DateTime
-      field :confirmed,   type: Boolean
-      field :description, type: String
-    CONTENT
-  end
+          <div class="title"><%= markdown slice.title %></div>
 
-  it "creates templates/example.hbs" do
-    expect("app/slices/example/templates/example.hbs").to contain <<-CONTENT
-      <li>
-        <label for="slices-{{id}}-title">Title</label>
-        <input type="text" id="slices-{{id}}-title" placeholder="Title…" value="{{title}}">
-      </li>
-      <li>
-        <label for="slices-{{id}}-images">Images</label>
-        {{#attachmentComposer field="images"}}
-          <textarea name="caption" placeholder="Caption…" class="full-height">{{caption}}</textarea>
-        {{/attachmentComposer}}
-      </li>
-      <li>
-        <label for="slices-{{id}}-featured_at">Featured at</label>
-        {{dateField field="featured_at"}}
-      </li>
-      <li>
-        <label>
-          <input type="checkbox" id="slices-{{id}}-confirmed" data-value="{{confirmed}}">
-          Confirmed
-        </label>
-      </li>
-      <li>
-        <label for="slices-{{id}}-description">Description</label>
-        <textarea id="slices-{{id}}-description" placeholder="Description…" rows="24">{{description}}</textarea>
-      </li>
+          <ul class="images">
+            <%- slice.images.each do |image| -%>
+              <li>
+                <%= image_if_present image.asset, :original %>
+                <div class="caption"><%= markdown image.caption %></div>
+              </li>
+            <%- end -%>
+          </ul>
 
-      <!--
-        To change the text that is displayed when this slice is minimised,
-        use the `slicePreview` helper below. The method is scoped to this slice
-        so you can easily access any contained elements.
+          <div class="featured_at"><%=l slice.featured_at %></div>
 
-        Examples:
-
-          return this.find('textarea').val();
-          return this.find('option:selected').text();
-
-      -->
-      {{#slicePreview}}
-      {{/slicePreview}}
-
-    CONTENT
-  end
-
-  it "creates views/show.html.erb" do
-    expect("app/slices/example/views/show.html.erb").to contain <<-CONTENT
-      <div class="slice example">
-
-        <!--
-          Stick the HTML that should be rendered when your slice is displayed here.
-
-          You can refer to data stored on your slice by calling slice.foo inside
-          a normal ERB code block.
-        -->
-
-        <div class="title"><%= markdown slice.title %></div>
-
-        <ul class="images">
-          <%- slice.images.each do |image| -%>
-            <li>
-              <%= image_if_present image.asset, :original %>
-              <div class="caption"><%= markdown image.caption %></div>
-            </li>
+          <%- if slice.confirmed? -%>
+            <div class="confirmed">Confirmed!</div>
           <%- end -%>
-        </ul>
 
-        <div class="featured_at"><%=l slice.featured_at %></div>
+          <div class="description"><%= markdown slice.description %></div>
 
-        <%- if slice.confirmed? -%>
-          <div class="confirmed">Confirmed!</div>
-        <%- end -%>
+          <p>Change me by editing app/slices/example/views/show.html.erb</p>
 
-        <div class="description"><%= markdown slice.description %></div>
-
-        <p>Change me by editing app/slices/example/views/show.html.erb</p>
-
-      </div>
-    CONTENT
-  end
-end
-
-describe "rails g slice example example:text (a field whose name matches the slice name)" do
-  before do
-    run_generator "slice example example:text"
+        </div>
+      CONTENT
+    end
   end
 
-  after do
-    FileUtils.rm_rf "app/slices/example"
+  describe "rails g slice example example:text (a field whose name matches the slice name)" do
+    before do
+      run_generator %w(example example:text)
+    end
+
+    it "creates templates/examples.hbs without a label" do
+      expect(file("app/slices/example/templates/example.hbs")).to contain <<-CONTENT
+        <li>
+          <textarea id="slices-{{id}}-example" placeholder="Example…" rows="24">{{example}}</textarea>
+        </li>
+      CONTENT
+    end
   end
 
-  it "creates templates/examples.hbs without a label" do
-    expect("app/slices/example/templates/example.hbs").to contain <<-CONTENT
-      <li>
-        <textarea id="slices-{{id}}-example" placeholder="Example…" rows="24">{{example}}</textarea>
-      </li>
-    CONTENT
-  end
-end
+  describe "rails g slice example_form" do
+    before do
+      run_generator %w(example_form)
+    end
 
-describe "rails g slice example_form" do
-  before do
-    run_generator "slice example_form"
-  end
-
-  after do
-    FileUtils.rm_rf "app/slices/example_form"
-  end
-
-  it "creates example_form_slice.rb with post handling options" do
-    expect("app/slices/example_form/example_form_slice.rb").to contain <<-CONTENT
-      # The handle_post method will get passed the params from the POST
-      # request, and should return true or false, depending on whether or
-      # not processing was successful.
-      #
-      # def handle_post(params)
-      # end
-      #
-      #
-      # Form slices get a chance to set a flash message after they have
-      # successfully handled a post. Set 'name' in the flash key to
-      # something specific to this slice.
-      #
-      # def set_success_message(flash)
-      #   flash['slices.name.notice'] = 'Nicely done'
-      # end
-      #
-      #
-      # After a successful POST request the CMS will redirect the user to a
-      # URL (this prevents them from being able to re-submit the form by
-      # reloading the page). This is the URL they end up at.
-      #
-      # def redirect_url
-      #   '/path/to/a/page'
-      # end
-    CONTENT
-  end
-
-  it "creates show.html.erb with a form tag in place" do
-    expect("app/slices/example_form/views/show.html.erb").to contain <<-CONTENT
-      <%= form_for slice, url: slice.page.path do |f| %>
-        <!--
-          Stick the HTML that should be rendered when your slice is displayed here.
-
-          You can refer to data stored on your slice by calling slice.foo inside
-          a normal ERB code block.
-
-          For more information on available form helpers, see:
-          http://guides.rubyonrails.org/form_helpers.html
-        -->
-        <p>Change me by editing app/slices/example_form/views/show.html.erb</p>
-      <% end %>
-    CONTENT
-  end
-end
-
-describe "rails g slice example_set published_at:datetime --with-entry-templates --with-identical-entries" do
-  before do
-    run_generator "slice example_set published_at:datetime --with-entry-templates --with-identical-entries"
-  end
-
-  after do
-    FileUtils.rm_rf "app/slices/example_set"
-  end
-
-  it "creates example.rb" do
-    expect("app/slices/example_set/example.rb").to contain <<-CONTENT
-      class Example < Page
-        field :published_at, type: DateTime
-
-        def entry?
-          true
-        end
-
-        def template
-          "example_set/views/show"
-        end
-
-        # Uncomment the as_json method if the page defines fields that are
-        # shown in the admin UI. Pass a hash to merge() that contains each
-        # field.
+    it "creates example_form_slice.rb with post handling options" do
+      expect(file("app/slices/example_form/example_form_slice.rb")).to contain <<-CONTENT
+        # The handle_post method will get passed the params from the POST
+        # request, and should return true or false, depending on whether or
+        # not processing was successful.
         #
-        # def as_json(options = {})
-        #   super.merge(published: published.to_s)
+        # def handle_post(params)
         # end
-      end
-    CONTENT
-  end
-
-  it "creates example_presenter.rb" do
-    expect("app/slices/example_set/example_presenter.rb").to contain <<-CONTENT
-      class ExamplePresenter < PagePresenter
-        include EntryPresenter
-
-        # We need to tell the admin UI which fields to show when presenting a
-        # table of entries in the admin UI. Each key in the column hash should
-        # be a symbol matching the name of one of the fields defined on the
-        # page.
         #
-        # The hash's values (e.g. 'Date Published') will be used for the
-        # column headings in the admin UI.
+        #
+        # Form slices get a chance to set a flash message after they have
+        # successfully handled a post. Set 'name' in the flash key to
+        # something specific to this slice.
+        #
+        # def set_success_message(flash)
+        #   flash['slices.name.notice'] = 'Nicely done'
+        # end
+        #
+        #
+        # After a successful POST request the CMS will redirect the user to a
+        # URL (this prevents them from being able to re-submit the form by
+        # reloading the page). This is the URL they end up at.
+        #
+        # def redirect_url
+        #   '/path/to/a/page'
+        # end
+      CONTENT
+    end
 
-        @columns = {
-          name: 'Name',
-          # published_at: 'Date Published'
-        }
-        class << self
-          attr_reader :columns
-        end
+    it "creates show.html.erb with a form tag in place" do
+      expect(file("app/slices/example_form/views/show.html.erb")).to contain <<-CONTENT
+        <%= form_for slice, url: slice.page.path do |f| %>
+          <!--
+            Stick the HTML that should be rendered when your slice is displayed here.
 
-        def main_extra_templates
-          super + ['example_set/example_main']
-        end
+            You can refer to data stored on your slice by calling slice.foo inside
+            a normal ERB code block.
 
-        def meta_extra_templates
-          super + ['example_set/example_meta']
-        end
-
-        # The CMS needs to know how to present the data stored on a page;
-        # it's not always good enough just to convert it to a string and
-        # render it into the page. You can access the page through the @source
-        # variable.
-
-        def name
-          @source.name.blank? ? "(name isn't set)" : @source.name
-        end
-      end
-    CONTENT
+            For more information on available form helpers, see:
+            http://guides.rubyonrails.org/form_helpers.html
+          -->
+          <p>Change me by editing app/slices/example_form/views/show.html.erb</p>
+        <% end %>
+      CONTENT
+    end
   end
 
-  it "creates example_set_slice.rb" do
-    expect("app/slices/example_set/example_set_slice.rb").to contain <<-CONTENT
-      class ExampleSetSlice < SetSlice
-        restricted_slice
+  describe "rails g slice example_set published_at:datetime --with-entry-templates --with-identical-entries" do
+    before do
+      run_generator %w(example_set published_at:datetime --with-entry-templates --with-identical-entries)
+    end
 
-        def addable_entries?
-          false
+    it "creates example.rb" do
+      expect(file("app/slices/example_set/example.rb")).to contain <<-CONTENT
+        class Example < Page
+          field :published_at, type: DateTime
+
+          def entry?
+            true
+          end
+
+          def template
+            "example_set/views/show"
+          end
+
+          # Uncomment the as_json method if the page defines fields that are
+          # shown in the admin UI. Pass a hash to merge() that contains each
+          # field.
+          #
+          # def as_json(options = {})
+          #   super.merge(published: published.to_s)
+          # end
         end
+      CONTENT
+    end
 
-        def editable_entries?
-          false
+    it "creates example_presenter.rb" do
+      expect(file("app/slices/example_set/example_presenter.rb")).to contain <<-CONTENT
+        class ExamplePresenter < PagePresenter
+          include EntryPresenter
+
+          # We need to tell the admin UI which fields to show when presenting a
+          # table of entries in the admin UI. Each key in the column hash should
+          # be a symbol matching the name of one of the fields defined on the
+          # page.
+          #
+          # The hash's values (e.g. 'Date Published') will be used for the
+          # column headings in the admin UI.
+
+          @columns = {
+            name: 'Name',
+            # published_at: 'Date Published'
+          }
+          class << self
+            attr_reader :columns
+          end
+
+          def main_extra_templates
+            super + ['example_set/example_main']
+          end
+
+          def meta_extra_templates
+            super + ['example_set/example_meta']
+          end
+
+          # The CMS needs to know how to present the data stored on a page;
+          # it's not always good enough just to convert it to a string and
+          # render it into the page. You can access the page through the @source
+          # variable.
+
+          def name
+            @source.name.blank? ? "(name isn't set)" : @source.name
+          end
         end
-      end
-    CONTENT
-  end
+      CONTENT
+    end
 
-  it "creates templates/example_main.hbs" do
-    expect("app/slices/example_set/templates/example_main.hbs").to contain <<-CONTENT
-      <!--
-        Any extra fields required for editing entries can be added here.
+    it "creates example_set_slice.rb" do
+      expect(file("app/slices/example_set/example_set_slice.rb")).to contain <<-CONTENT
+        class ExampleSetSlice < SetSlice
+          restricted_slice
 
-        For example:
+          def addable_entries?
+            false
+          end
 
+          def editable_entries?
+            false
+          end
+        end
+      CONTENT
+    end
+
+    it "creates templates/example_main.hbs" do
+      expect(file("app/slices/example_set/templates/example_main.hbs")).to contain <<-CONTENT
+        <!--
+          Any extra fields required for editing entries can be added here.
+
+          For example:
+
+          <li>
+            <label for="meta-published_at">Published at</label>
+            <input type="datetime" id="meta-published_at" value="{{published_at}}">
+          </li>
+        -->
+      CONTENT
+    end
+
+    it "creates templates/example_meta.hbs" do
+      expect(file("app/slices/example_set/templates/example_meta.hbs")).to contain <<-CONTENT
+        <!--
+          Any extra meta field required for editing entries can be added here.
+
+          For example:
+
+          <li>
+            <label for="meta-published_at">Published at</label>
+            <input type="datetime" id="meta-published_at" value="{{published_at}}">
+          </li>
+        -->
+      CONTENT
+    end
+
+    it "creates templates/example_set.hbs" do
+      expect(file("app/slices/example_set/templates/example_set.hbs")).to contain <<-CONTENT
         <li>
-          <label for="meta-published_at">Published at</label>
-          <input type="datetime" id="meta-published_at" value="{{published_at}}">
+          <label for="slices-{{id}}-per_page">Per page</label>
+          <input type="text" id="slices-{{id}}-per_page" value="{{per_page}}">
         </li>
-      -->
-    CONTENT
-  end
+      CONTENT
+    end
 
-  it "creates templates/example_meta.hbs" do
-    expect("app/slices/example_set/templates/example_meta.hbs").to contain <<-CONTENT
-      <!--
-        Any extra meta field required for editing entries can be added here.
-
-        For example:
-
-        <li>
-          <label for="meta-published_at">Published at</label>
-          <input type="datetime" id="meta-published_at" value="{{published_at}}">
-        </li>
-      -->
-    CONTENT
-  end
-
-  it "creates templates/example_set.hbs" do
-    expect("app/slices/example_set/templates/example_set.hbs").to contain <<-CONTENT
-      <li>
-        <label for="slices-{{id}}-per_page">Per page</label>
-        <input type="text" id="slices-{{id}}-per_page" value="{{per_page}}">
-      </li>
-    CONTENT
-  end
-
-  it "creates views/set.html.erb" do
-    expect("app/slices/example_set/views/set.html.erb").to contain <<-CONTENT
-      <%= will_paginate slice.page_entries, renderer: SetLinkRenderer, class: 'pagination above' %>
-      <ul class="entries">
-        <% slice.page_entries.each do |entry| -%>
-          <li><%= link_to entry.name, entry.path %></li>
-        <% end -%>
-      </ul>
-      <%= will_paginate slice.page_entries, renderer: SetLinkRenderer, class: 'pagination below' %>
-    CONTENT
+    it "creates views/set.html.erb" do
+      expect(file("app/slices/example_set/views/set.html.erb")).to contain <<-CONTENT
+        <%= will_paginate slice.page_entries, renderer: SetLinkRenderer, class: 'pagination above' %>
+        <ul class="entries">
+          <% slice.page_entries.each do |entry| -%>
+            <li><%= link_to entry.name, entry.path %></li>
+          <% end -%>
+        </ul>
+        <%= will_paginate slice.page_entries, renderer: SetLinkRenderer, class: 'pagination below' %>
+      CONTENT
+    end
   end
 end
 

--- a/spec/requests/admin/admin_sets_acceptance_spec.rb
+++ b/spec/requests/admin/admin_sets_acceptance_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 require 'spec_helper'
 
 describe "The set entries view", type: :request, js: true do

--- a/spec/requests/admin/assets/changing_an_assets_name_spec.rb
+++ b/spec/requests/admin/assets/changing_an_assets_name_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 require 'spec_helper'
 
 describe "Changing an asset's name in the asset editor", type: :request, js: true do

--- a/spec/requests/admin/assets/page_references_spec.rb
+++ b/spec/requests/admin/assets/page_references_spec.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 require 'spec_helper'
 
 describe "Viewing page_paths on an asset", type: :request, js: true do

--- a/spec/requests/admin/set/editing_spec.rb
+++ b/spec/requests/admin/set/editing_spec.rb
@@ -1,5 +1,3 @@
-
-# -*- encoding: utf-8 -*-
 require 'spec_helper'
 
 describe "Viewing the sets entries page", type: :request, js: true do


### PR DESCRIPTION
The diff isn't as scary if you ignore whitespace (`?w=1` in url).

One thing that is annoying me and I can't get rid of: when I run `install_generator_spec.rb` I get a bunch of

```
/Users/ben/.rbenv/versions/2.1.6/bin/ruby: No such file or directory -- script/rails (LoadError)
```

errors. After some digging I found that it's because `Slices::InstallGenerator` [calls `Rails::Generators::Actions#generate`](https://github.com/withassociates/slices/blob/ca1c85995bad347c513f8223d30c68b60e9d4b11/lib/generators/slices/install_generator.rb#L40), which in turn ends up [calling `script/rails`](https://github.com/rails/rails/blob/v3.2.18/railties/lib/rails/generators/actions.rb#L244). So the generator assumes it's being run from an app root. So then how do you make this work in tests/specs? I don't know. There are some issues open in places:

* https://github.com/alexrothenberg/ammeter/issues/14
* https://github.com/rails/rails/issues/8894

but none seem to have a solution.