### PR TITLE
Enable mongoid safe mode

### DIFF
--- a/spec/dummy/config/mongoid.yml
+++ b/spec/dummy/config/mongoid.yml
@@ -5,6 +5,7 @@ development:
       hosts:
         - localhost:27017
       options:
+        safe: true
   options:
     # Configuration for whether or not to allow access to fields that do
     # not have a field definition on the model. (default: true)
@@ -50,5 +51,6 @@ test:
       hosts:
         - localhost:27017
       options:
+        safe: true
         max_retries: 1
         retry_interval: 0


### PR DESCRIPTION
Obvious.

I wonder if this will shed more light on those occasional `Mongoid::Errors::DocumentNotFound` spec errors (like [this](https://travis-ci.org/withassociates/slices/jobs/79132192) one).