### PR TITLE
Stub out `Slices::InstallGenerator#optionally_create_mongoid_yaml`

### DIFF
--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -6,6 +6,10 @@ describe Slices::InstallGenerator do
 
   before do
     prepare_destination
+
+    # avoid `/bin/ruby: No such file or directory -- script/rails (LoadError)` warnings
+    allow(generator).to receive(:optionally_create_mongoid_yaml)
+
     run_generator
   end
 


### PR DESCRIPTION
Following on from my chat in https://github.com/withassociates/slices/pull/119.

It calls `generate` which shells out to `script/rails`. The way the generator/specs are set up means it doesn't exist: the generator expects to be run in `Rails.root` (so in this case, because Slices is an engine, in `spec/dummy`). But if you run it there the spec ends up deleting everything (because it calls `prepare_destination`; hence why `destination` is set to `Rails.root.join('tmp')`). I couldn't find an answer within the time box I gave myself.