### PR TITLE
Session error messages

### DIFF
--- a/app/assets/stylesheets/slices/admin.css.erb
+++ b/app/assets/stylesheets/slices/admin.css.erb
@@ -1305,6 +1305,10 @@ a.remove-asset {
   font-size: 11px;
   font-family: "Lucida Grande", Arial, sans-serif;
 }
+.devise .login form p.flash-message {
+  text-align: center;
+  margin-bottom: 10px;
+}
 
 /*SPECIFIC TO It's Nice That*/
 .multi-tag-list li.first_not_shown_in_category_list,

--- a/app/views/admin/auth/sessions/_form.html.erb
+++ b/app/views/admin/auth/sessions/_form.html.erb
@@ -1,5 +1,8 @@
 <div class="login">
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <% if flash[:alert].present? %>
+      <%= flash[:alert] %>
+    <% end %>
 
     <p>
       <%= f.label :email %><br />

--- a/app/views/admin/auth/sessions/_form.html.erb
+++ b/app/views/admin/auth/sessions/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="login">
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
     <% if flash[:alert].present? %>
-      <%= flash[:alert] %>
+      <p class="flash-message"><%= flash[:alert] %></p>
     <% end %>
 
     <p>

--- a/spec/requests/admin/admin_password_reset_spec.rb
+++ b/spec/requests/admin/admin_password_reset_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 describe "Password reset for /admin", type: :request, js: true do
-
-  it "Reset admin users password" do
+  before do
     Devise::Mailer.default_url_options[:host] = "example.com"
     Admin.create!(email: 'hello@withassociates.com', password: '123456')
     StandardTree.build_minimal
@@ -19,7 +18,9 @@ describe "Password reset for /admin", type: :request, js: true do
     url = email.body.to_s[/example\.com(.*)\"/, 1]
     wait_for_ajax
     visit url
+  end
 
+  it "Reset admin users password" do
     fill_in 'New password', with: 'hello12'
     fill_in 'Confirm new password', with: 'hello12'
     click_on 'Change my password'
@@ -27,5 +28,14 @@ describe "Password reset for /admin", type: :request, js: true do
     expect(page.current_path).to eq('/admin/site_maps')
   end
 
+
+  it "Shows an error if the new passwords do not match" do
+    fill_in 'New password', with: 'hello12'
+    fill_in 'Confirm new password', with: 'hello121212'
+    click_on 'Change my password'
+
+    expect(page.current_path).to eq('/admin/password')
+    expect(page).to have_content('error')
+  end
 end
 

--- a/spec/requests/admin/admin_sessions_acceptance_spec.rb
+++ b/spec/requests/admin/admin_sessions_acceptance_spec.rb
@@ -16,6 +16,21 @@ describe "Authentication for /admin", type: :request, js: true do
     expect(page.current_path).to eq('/admin/site_maps')
   end
 
+  it "should show an error if password is incorrect" do
+    Admin.create!(email: 'hello@withassociates.com', password: '123456')
+    StandardTree.build_minimal
+
+    visit '/admin/sign_in'
+    expect(page).to have_no_css('header li a', text: 'Log out')
+
+    fill_in 'Email', with: 'hello@withassociates.com'
+    fill_in 'Password', with: 'incorrect'
+    click_on 'Sign in'
+
+    expect(page.current_path).to eq('/admin/sign_in')
+    expect(page).to have_content('Invalid')
+  end
+
   it "should redirect to sign in page if not signed in" do
     visit '/admin/site_maps'
     expect(page.current_path).to eq('/admin/sign_in')


### PR DESCRIPTION
![screen shot 2016-01-06 at 14 15 17](https://cloud.githubusercontent.com/assets/2891685/12144502/fb123128-b47f-11e5-8b76-8119697e4c16.png)

Closes #96.

Adding error messages to the admin authentication path.

Something annoying, though: if you visit /admin, upon redirecting to /admin/sign_in, it tells you "You need to sign in or sign up before continuing." Getting rid of that while keeping the valuable "Incorrect email or password" alert would involve changing the string in the locales -- perhaps generating custom error messages into the Rails app upon Slices' initial install. All in all, seems a lot of work to get rid of one string that is half-informative and hardly a nuisance.