### PR TITLE
Update stringex gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       paperclip (~> 3.1.4)
       rails (~> 3.2.18)
       redcarpet (~> 3.0.0)
-      stringex (~> 1.4.0)
+      stringex (~> 2.5.2)
       will_paginate_mongoid (~> 2.0)
 
 GEM
@@ -194,7 +194,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    stringex (1.4.0)
+    stringex (2.5.2)
     thor (0.19.1)
     tilt (1.4.1)
     treetop (1.4.15)

--- a/slices.gemspec
+++ b/slices.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails'             , '~> 3.2.18'
   s.add_dependency 'redcarpet'         , '~> 3.0.0'
   s.add_dependency 'RedCloth'          , '~> 4.2.9'
-  s.add_dependency 'stringex'          , '~> 1.4.0'
+  s.add_dependency 'stringex'          , '~> 2.5.2'
   s.add_dependency 'will_paginate_mongoid', '~> 2.0'
 
   src_files           = Dir['{app,lib}/**/*']


### PR DESCRIPTION
Newer versions of _stringex_ will strip out "|" and possibly other special characters when generating page permalinks.
