### PR TITLE
Add options to update_attributes method signatures.

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -141,7 +141,7 @@ class Page
     "pages/show"
   end
 
-  def update_attributes(attributes)
+  def update_attributes(attributes, options = {})
     attributes = attributes.symbolize_keys
 
     unless home?
@@ -159,7 +159,6 @@ class Page
       update_path_for_children if attributes.has_key?(:path)
     end
   end
-
 
   # Added in merge or page & content
   def set_keywords

--- a/lib/slices/has_slices.rb
+++ b/lib/slices/has_slices.rb
@@ -28,7 +28,7 @@ module Slices
       end
     end
 
-    def update_attributes(attributes)
+    def update_attributes(attributes, options = {})
       [:slices, :set_slices].each do |embed_name|
         next if attributes[embed_name].nil?
 


### PR DESCRIPTION
`my_page.update_attributes!(active: true)` throws `ArgumentError: wrong number of arguments (2 for 1)`. This is because slices overrides mongoid's `update_attributes` method, but does not maintain the same method signature; it expects only one argument, rather than two.

When the slices implementation of `update_attributes` is called by mongoid's `update_attributes!`, the wrong number of arguments is passed and an error occurs.
