### PR TITLE
Redirect page path to external_url if set

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -29,7 +29,7 @@ class PagesController < SlicesController
       page = Page.find_by_path(request.path)
       raise Page::NotFound unless page.active?
     end
-    render_page(page)
+    redirect_or_render_page(page)
   end
 
   private

--- a/app/controllers/slices_controller.rb
+++ b/app/controllers/slices_controller.rb
@@ -35,6 +35,11 @@ class SlicesController < ActionController::Base
 
   private
 
+  def redirect_or_render_page(page, status = 200)
+    return redirect_to(page.external_url) if page.external_url?
+    render_page(page, status)
+  end
+
   def render_page(page, status = 200)
     @page = page
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe PagesController, type: :controller do
+  context "GET :show" do
+    let :page do
+      Page.new(
+        external_url: 'http://www.example.com',
+        active: true
+      )
+    end
+
+    it "redirects to the external url" do
+      expect(Page).to receive(:find_by_path).and_return(page)
+      get :show, path: nil
+      expect(response).to redirect_to 'http://www.example.com'
+    end
+  end
+end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -3,10 +3,7 @@ require 'spec_helper'
 describe PagesController, type: :controller do
   context "GET :show" do
     let :page do
-      Page.new(
-        external_url: 'http://www.example.com',
-        active: true
-      )
+      Page.new(active: true, external_url: 'http://www.example.com')
     end
 
     it "redirects to the external url" do


### PR DESCRIPTION
When `external_url` is set, it is used for the navigation link. It should also redirect when you visit that page path.
