### PR TITLE
Remove Admin::Assets#show route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 - [#152](https://github.com/withassociates/slices/pull/152): Fix issue where sitemap wasn't showing correct icons for page types and wasn't showing child pages in correct order
+- [#161](https://github.com/withassociates/slices/pull/161): Remove the Admin::Assets#show route
 
 ## 2.0.0 / 2016-01-15
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     resources :pages, :except => [:index, :edit] do
       resources :entries, :only => [:index]
     end
-    resources :assets
+    resources :assets, :except => [:show]
     resources :snippets
     resources :admins
   end


### PR DESCRIPTION
This will 404 instead of throwing an error if a user tries to access the
show view of an Asset.
