### PR TITLE
Replace filename by random one to prevent Errno::ENAMETOOLONG

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -184,12 +184,7 @@ class Asset
   end
 
   def sanitize(filename)
-    file.send(:cleanup_filename, filename).tap do |name|
-      if self.file && self.file.original_filename
-        extension = normalized_extension
-        name << extension unless name.ends_with?(extension)
-      end
-    end
+    SecureRandom.hex
   end
 
   def normalized_extension


### PR DESCRIPTION
Horrible... 🚢
